### PR TITLE
Add watchOS and tvOS support.

### DIFF
--- a/RNCryptor tvOS/Info.plist
+++ b/RNCryptor tvOS/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/RNCryptor tvOS/RNCryptor tvOS.h
+++ b/RNCryptor tvOS/RNCryptor tvOS.h
@@ -1,0 +1,22 @@
+//
+//  RNCryptor tvOS.h
+//  RNCryptor tvOS
+//
+//  Created by Jeff Kelley on 11/15/16.
+//  Copyright © 2016 Rob Napier. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for RNCryptor tvOS.
+FOUNDATION_EXPORT double RNCryptor_tvOSVersionNumber;
+
+//! Project version string for RNCryptor tvOS.
+FOUNDATION_EXPORT const unsigned char RNCryptor_tvOSVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <RNCryptor/PublicHeader.h>
+
+#import <RNCryptor/RNCryptor.h>
+#import <RNCryptor/RNDecryptor.h>
+#import <RNCryptor/RNEncryptor.h>
+#import <RNCryptor/RNCryptorEngine.h>

--- a/RNCryptor watchOS/Info.plist
+++ b/RNCryptor watchOS/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/RNCryptor watchOS/RNCryptor watchOS.h
+++ b/RNCryptor watchOS/RNCryptor watchOS.h
@@ -1,0 +1,22 @@
+//
+//  RNCryptor watchOS.h
+//  RNCryptor watchOS
+//
+//  Created by Jeff Kelley on 11/15/16.
+//  Copyright © 2016 Rob Napier. All rights reserved.
+//
+
+#import <WatchKit/WatchKit.h>
+
+//! Project version number for RNCryptor watchOS.
+FOUNDATION_EXPORT double RNCryptor_watchOSVersionNumber;
+
+//! Project version string for RNCryptor watchOS.
+FOUNDATION_EXPORT const unsigned char RNCryptor_watchOSVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <RNCryptor/PublicHeader.h>
+
+#import <RNCryptor/RNCryptor.h>
+#import <RNCryptor/RNDecryptor.h>
+#import <RNCryptor/RNEncryptor.h>
+#import <RNCryptor/RNCryptorEngine.h>

--- a/RNCryptor-objc.podspec
+++ b/RNCryptor-objc.podspec
@@ -25,5 +25,7 @@ LIC
   s.frameworks = 'Security'
   s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'
+  s.watchos.deployment_target = '2.0'
+  s.tvos.deployment_target = '9.0'
 end
 

--- a/RNCryptor.xcodeproj/project.pbxproj
+++ b/RNCryptor.xcodeproj/project.pbxproj
@@ -7,6 +7,30 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F3717571DDB9C60009E537B /* RNCryptor watchOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F3717551DDB9C60009E537B /* RNCryptor watchOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F37175C1DDB9CB0009E537B /* RNCryptor.m in Sources */ = {isa = PBXBuildFile; fileRef = FB75651B1512D3E9007B806B /* RNCryptor.m */; };
+		1F37175D1DDB9CB0009E537B /* RNDecryptor.m in Sources */ = {isa = PBXBuildFile; fileRef = FB7565241512D9BE007B8078 /* RNDecryptor.m */; };
+		1F37175E1DDB9CB0009E537B /* RNEncryptor.m in Sources */ = {isa = PBXBuildFile; fileRef = FB7565241512D9BE007B8074 /* RNEncryptor.m */; };
+		1F37175F1DDB9CB0009E537B /* RNCryptorEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = FB7565241512D9BE007B807C /* RNCryptorEngine.m */; };
+		1F3717601DDB9CB7009E537B /* RNCryptor.h in Headers */ = {isa = PBXBuildFile; fileRef = FB75651A1512D3E9007B806B /* RNCryptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F3717611DDB9CBC009E537B /* RNDecryptor.h in Headers */ = {isa = PBXBuildFile; fileRef = FB7565241512D9BE007B807A /* RNDecryptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F3717621DDB9CC3009E537B /* RNEncryptor.h in Headers */ = {isa = PBXBuildFile; fileRef = FB7565241512D9BE007B8076 /* RNEncryptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F3717631DDB9CC9009E537B /* RNCryptorEngine.h in Headers */ = {isa = PBXBuildFile; fileRef = FB7565241512D9BE007B807E /* RNCryptorEngine.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1F3717641DDB9CCE009E537B /* RNCryptor+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = FB7565241512D9BE007B8084 /* RNCryptor+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1F37176E1DDB9D1B009E537B /* RNCryptor tvOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F37176C1DDB9D1B009E537B /* RNCryptor tvOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F3717731DDB9D4C009E537B /* RNCryptor.h in Headers */ = {isa = PBXBuildFile; fileRef = FB75651A1512D3E9007B806B /* RNCryptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F3717741DDB9D50009E537B /* RNCryptor.m in Sources */ = {isa = PBXBuildFile; fileRef = FB75651B1512D3E9007B806B /* RNCryptor.m */; };
+		1F3717751DDB9D52009E537B /* RNDecryptor.h in Headers */ = {isa = PBXBuildFile; fileRef = FB7565241512D9BE007B807A /* RNDecryptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F3717761DDB9D56009E537B /* RNDecryptor.m in Sources */ = {isa = PBXBuildFile; fileRef = FB7565241512D9BE007B8078 /* RNDecryptor.m */; };
+		1F3717771DDB9D59009E537B /* RNEncryptor.h in Headers */ = {isa = PBXBuildFile; fileRef = FB7565241512D9BE007B8076 /* RNEncryptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F3717781DDB9D5D009E537B /* RNEncryptor.m in Sources */ = {isa = PBXBuildFile; fileRef = FB7565241512D9BE007B8074 /* RNEncryptor.m */; };
+		1F3717791DDB9D60009E537B /* RNCryptorEngine.h in Headers */ = {isa = PBXBuildFile; fileRef = FB7565241512D9BE007B807E /* RNCryptorEngine.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1F37177A1DDB9D63009E537B /* RNCryptorEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = FB7565241512D9BE007B807C /* RNCryptorEngine.m */; };
+		1F37177B1DDB9D66009E537B /* RNCryptor+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = FB7565241512D9BE007B8084 /* RNCryptor+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1F37177D1DDB9DF9009E537B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F37177C1DDB9DF9009E537B /* Foundation.framework */; };
+		1F37177F1DDB9DFD009E537B /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F37177E1DDB9DFD009E537B /* Security.framework */; };
+		1F3717811DDB9E07009E537B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F3717801DDB9E07009E537B /* Foundation.framework */; };
+		1F3717831DDB9E0A009E537B /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F3717821DDB9E0A009E537B /* Security.framework */; };
 		4ABDC61718615875000DE03F /* RNCryptor.h in Headers */ = {isa = PBXBuildFile; fileRef = FB75651A1512D3E9007B806B /* RNCryptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4ABDC61918615894000DE03F /* RNEncryptor.h in Headers */ = {isa = PBXBuildFile; fileRef = FB7565241512D9BE007B8076 /* RNEncryptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4ABDC61C18615894000DE03F /* RNCryptorEngine.h in Headers */ = {isa = PBXBuildFile; fileRef = FB7565241512D9BE007B807E /* RNCryptorEngine.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -81,6 +105,16 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1F3717531DDB9C5F009E537B /* RNCryptor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RNCryptor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F3717551DDB9C60009E537B /* RNCryptor watchOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RNCryptor watchOS.h"; sourceTree = "<group>"; };
+		1F3717561DDB9C60009E537B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1F37176A1DDB9D1B009E537B /* RNCryptor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RNCryptor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F37176C1DDB9D1B009E537B /* RNCryptor tvOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RNCryptor tvOS.h"; sourceTree = "<group>"; };
+		1F37176D1DDB9D1B009E537B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1F37177C1DDB9DF9009E537B /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS3.1.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		1F37177E1DDB9DFD009E537B /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS3.1.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
+		1F3717801DDB9E07009E537B /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS10.1.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		1F3717821DDB9E0A009E537B /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS10.1.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
 		659134E91B14262B00B82A96 /* RNCryptor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RNCryptor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		659134EC1B14262C00B82A96 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		659134ED1B14262C00B82A96 /* RNCryptor iOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RNCryptor iOS.h"; sourceTree = "<group>"; };
@@ -123,6 +157,24 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		1F37174F1DDB9C5F009E537B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F37177D1DDB9DF9009E537B /* Foundation.framework in Frameworks */,
+				1F37177F1DDB9DFD009E537B /* Security.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F3717661DDB9D1B009E537B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F3717811DDB9E07009E537B /* Foundation.framework in Frameworks */,
+				1F3717831DDB9E0A009E537B /* Security.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		659134E51B14262B00B82A96 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -169,6 +221,40 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1F3717541DDB9C60009E537B /* RNCryptor watchOS */ = {
+			isa = PBXGroup;
+			children = (
+				1F3717551DDB9C60009E537B /* RNCryptor watchOS.h */,
+				1F37175B1DDB9C8A009E537B /* Supporting Files */,
+			);
+			path = "RNCryptor watchOS";
+			sourceTree = "<group>";
+		};
+		1F37175B1DDB9C8A009E537B /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				1F3717561DDB9C60009E537B /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		1F37176B1DDB9D1B009E537B /* RNCryptor tvOS */ = {
+			isa = PBXGroup;
+			children = (
+				1F37176C1DDB9D1B009E537B /* RNCryptor tvOS.h */,
+				1F3717721DDB9D26009E537B /* Supporting Files */,
+			);
+			path = "RNCryptor tvOS";
+			sourceTree = "<group>";
+		};
+		1F3717721DDB9D26009E537B /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				1F37176D1DDB9D1B009E537B /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
 		659134EA1B14262C00B82A96 /* RNCryptor iOS */ = {
 			isa = PBXGroup;
 			children = (
@@ -249,6 +335,8 @@
 				AB13428115E0FC2300456914 /* RNCryptor OS X */,
 				FB6AC68E16F6704200CA0C0A /* rncrypt */,
 				659134EA1B14262C00B82A96 /* RNCryptor iOS */,
+				1F3717541DDB9C60009E537B /* RNCryptor watchOS */,
+				1F37176B1DDB9D1B009E537B /* RNCryptor tvOS */,
 				FB7564F21512D3C4007B806B /* Frameworks */,
 				FB7564F11512D3C4007B806B /* Products */,
 			);
@@ -264,6 +352,8 @@
 				AB13427A15E0FC2300456914 /* RNCryptor.framework */,
 				FB6AC68C16F6704100CA0C0A /* rncrypt */,
 				659134E91B14262B00B82A96 /* RNCryptor.framework */,
+				1F3717531DDB9C5F009E537B /* RNCryptor.framework */,
+				1F37176A1DDB9D1B009E537B /* RNCryptor.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -271,6 +361,10 @@
 		FB7564F21512D3C4007B806B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				1F3717821DDB9E0A009E537B /* Security.framework */,
+				1F3717801DDB9E07009E537B /* Foundation.framework */,
+				1F37177E1DDB9DFD009E537B /* Security.framework */,
+				1F37177C1DDB9DF9009E537B /* Foundation.framework */,
 				FBE8BC9D1D9072970070C8D0 /* Security.framework */,
 				FB7565221512D9A8007B806B /* Security.framework */,
 				FB7564F31512D3C4007B806B /* Foundation.framework */,
@@ -331,6 +425,32 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		1F3717501DDB9C5F009E537B /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F3717601DDB9CB7009E537B /* RNCryptor.h in Headers */,
+				1F3717621DDB9CC3009E537B /* RNEncryptor.h in Headers */,
+				1F3717641DDB9CCE009E537B /* RNCryptor+Private.h in Headers */,
+				1F3717611DDB9CBC009E537B /* RNDecryptor.h in Headers */,
+				1F3717631DDB9CC9009E537B /* RNCryptorEngine.h in Headers */,
+				1F3717571DDB9C60009E537B /* RNCryptor watchOS.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F3717671DDB9D1B009E537B /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F3717731DDB9D4C009E537B /* RNCryptor.h in Headers */,
+				1F3717771DDB9D59009E537B /* RNEncryptor.h in Headers */,
+				1F37177B1DDB9D66009E537B /* RNCryptor+Private.h in Headers */,
+				1F3717751DDB9D52009E537B /* RNDecryptor.h in Headers */,
+				1F3717791DDB9D60009E537B /* RNCryptorEngine.h in Headers */,
+				1F37176E1DDB9D1B009E537B /* RNCryptor tvOS.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		659134E61B14262B00B82A96 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -371,6 +491,42 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		1F3717521DDB9C5F009E537B /* RNCryptor watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1F37175A1DDB9C60009E537B /* Build configuration list for PBXNativeTarget "RNCryptor watchOS" */;
+			buildPhases = (
+				1F37174E1DDB9C5F009E537B /* Sources */,
+				1F37174F1DDB9C5F009E537B /* Frameworks */,
+				1F3717501DDB9C5F009E537B /* Headers */,
+				1F3717511DDB9C5F009E537B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "RNCryptor watchOS";
+			productName = "RNCryptor watchOS";
+			productReference = 1F3717531DDB9C5F009E537B /* RNCryptor.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		1F3717691DDB9D1B009E537B /* RNCryptor tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1F37176F1DDB9D1B009E537B /* Build configuration list for PBXNativeTarget "RNCryptor tvOS" */;
+			buildPhases = (
+				1F3717651DDB9D1B009E537B /* Sources */,
+				1F3717661DDB9D1B009E537B /* Frameworks */,
+				1F3717671DDB9D1B009E537B /* Headers */,
+				1F3717681DDB9D1B009E537B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "RNCryptor tvOS";
+			productName = "RNCryptor tvOS";
+			productReference = 1F37176A1DDB9D1B009E537B /* RNCryptor.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		659134E81B14262B00B82A96 /* RNCryptor iOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 659135001B14262C00B82A96 /* Build configuration list for PBXNativeTarget "RNCryptor iOS" */;
@@ -470,6 +626,14 @@
 				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Rob Napier";
 				TargetAttributes = {
+					1F3717521DDB9C5F009E537B = {
+						CreatedOnToolsVersion = 8.2;
+						ProvisioningStyle = Automatic;
+					};
+					1F3717691DDB9D1B009E537B = {
+						CreatedOnToolsVersion = 8.2;
+						ProvisioningStyle = Automatic;
+					};
 					659134E81B14262B00B82A96 = {
 						CreatedOnToolsVersion = 6.3.2;
 					};
@@ -492,11 +656,27 @@
 				FB7564FF1512D3C4007B806B /* RNCryptorTests */,
 				FB6AC68B16F6704100CA0C0A /* rncrypt */,
 				659134E81B14262B00B82A96 /* RNCryptor iOS */,
+				1F3717521DDB9C5F009E537B /* RNCryptor watchOS */,
+				1F3717691DDB9D1B009E537B /* RNCryptor tvOS */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		1F3717511DDB9C5F009E537B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F3717681DDB9D1B009E537B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		659134E71B14262B00B82A96 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -548,6 +728,28 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		1F37174E1DDB9C5F009E537B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F37175C1DDB9CB0009E537B /* RNCryptor.m in Sources */,
+				1F37175D1DDB9CB0009E537B /* RNDecryptor.m in Sources */,
+				1F37175E1DDB9CB0009E537B /* RNEncryptor.m in Sources */,
+				1F37175F1DDB9CB0009E537B /* RNCryptorEngine.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F3717651DDB9D1B009E537B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F3717781DDB9D5D009E537B /* RNEncryptor.m in Sources */,
+				1F37177A1DDB9D63009E537B /* RNCryptorEngine.m in Sources */,
+				1F3717761DDB9D56009E537B /* RNDecryptor.m in Sources */,
+				1F3717741DDB9D50009E537B /* RNCryptor.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		659134E41B14262B00B82A96 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -634,6 +836,164 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		1F3717581DDB9C60009E537B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "RNCryptor watchOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = net.robnapier.RNCryptor;
+				PRODUCT_NAME = RNCryptor;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 3.1;
+			};
+			name = Debug;
+		};
+		1F3717591DDB9C60009E537B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "RNCryptor watchOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = net.robnapier.RNCryptor;
+				PRODUCT_NAME = RNCryptor;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 3.1;
+			};
+			name = Release;
+		};
+		1F3717701DDB9D1B009E537B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "RNCryptor tvOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = net.robnapier.RNCryptor;
+				PRODUCT_NAME = RNCryptor;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 10.1;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		1F3717711DDB9D1B009E537B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "RNCryptor tvOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = net.robnapier.RNCryptor;
+				PRODUCT_NAME = RNCryptor;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 10.1;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		659134FC1B14262C00B82A96 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -954,6 +1314,24 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		1F37175A1DDB9C60009E537B /* Build configuration list for PBXNativeTarget "RNCryptor watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1F3717581DDB9C60009E537B /* Debug */,
+				1F3717591DDB9C60009E537B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1F37176F1DDB9D1B009E537B /* Build configuration list for PBXNativeTarget "RNCryptor tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1F3717701DDB9D1B009E537B /* Debug */,
+				1F3717711DDB9D1B009E537B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		659135001B14262C00B82A96 /* Build configuration list for PBXNativeTarget "RNCryptor iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (


### PR DESCRIPTION
This PR adds additional targets in Xcode for watchOS 2.0+ and tvOS 9.0+. It also modifies the `.podspec` file to enable those platforms to pull in RNCryptor-objc as a dependency.