### PR TITLE
Remove non-modular header from framework header

### DIFF
--- a/RNCryptor iOS/RNCryptor iOS.h
+++ b/RNCryptor iOS/RNCryptor iOS.h
@@ -19,4 +19,3 @@ FOUNDATION_EXPORT const unsigned char RNCryptor_iOSVersionString[];
 #import <RNCryptor/RNCryptor.h>
 #import <RNCryptor/RNDecryptor.h>
 #import <RNCryptor/RNEncryptor.h>
-#import <RNCryptor/RNCryptorEngine.h>


### PR DESCRIPTION
RNCryptorEngine.h is listed in the private headers section of the framework headers list, so it looks like it shouldn't be in the framework's umbrella header. I can't `@import` or `#import` RNCryptor-objc built as a framework in my iOS app, without this change.