### PR TITLE
Fix build settings for macOS framework

### DIFF
--- a/RNCryptor.xcodeproj/project.pbxproj
+++ b/RNCryptor.xcodeproj/project.pbxproj
@@ -1098,6 +1098,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/Developer/Library/Frameworks\"",
@@ -1108,6 +1109,7 @@
 				GCC_PREFIX_HEADER = "RNCryptor OS X/RNCryptor OS X-Prefix.pch";
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				INFOPLIST_FILE = "RNCryptor OS X/RNCryptor OS X-Info.plist";
+				LD_DYLIB_INSTALL_NAME = "@rpath/$(EXECUTABLE_PATH)";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "net.robnapier.${PRODUCT_NAME:rfc1034identifier}";
@@ -1126,6 +1128,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/Developer/Library/Frameworks\"",
@@ -1136,6 +1139,7 @@
 				GCC_PREFIX_HEADER = "RNCryptor OS X/RNCryptor OS X-Prefix.pch";
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				INFOPLIST_FILE = "RNCryptor OS X/RNCryptor OS X-Info.plist";
+				LD_DYLIB_INSTALL_NAME = "@rpath/$(EXECUTABLE_PATH)";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "net.robnapier.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = RNCryptor;

--- a/RNCryptor.xcodeproj/project.pbxproj
+++ b/RNCryptor.xcodeproj/project.pbxproj
@@ -1115,6 +1115,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "net.robnapier.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = RNCryptor;
 				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
 				WRAPPER_EXTENSION = framework;
 			};
 			name = Debug;
@@ -1144,6 +1145,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "net.robnapier.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = RNCryptor;
 				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
 				WRAPPER_EXTENSION = framework;
 			};
 			name = Release;


### PR DESCRIPTION
This PR will fix two build settings fo the macOS framework, when adding RNCryptor as Git submodule and then importing the RNCryotpr.xcodeproj into the own project.

1) **Dynamic Library Install Name:** Previously, the macOS framework used `/Library/Frameworks/$(EXECUTABLE_PATH)` as install name. However, when using the framework with this setting, any binary linking against RNCryptor links against `/Library/Frameworks/RNCryptor.framework` even when the framework is bundled with the app. To fix this, `@rpath` is used instead of `/Library/Frameworks`.
2) **Skip Install:** Previously, *Skip Install* was set to `NO`. As a consequence, when archiving the main project, Xcode will copy RNCryptor as a standalone framework into the archive. The archive then will contain both the main app bundling RNCryptor as well as the standalone RNCryptor Framework. And this will confuse Xcode when trying to export or upload the archive to the App Store.

I'm not entirely sure that these settings are best for all use cases. Open for discussion 🙂.