### PR TITLE
Add basic SPM support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+import PackageDescription
+
+let package = Package(
+    name: "RNCryptor-objc",
+    products: [
+        .library(
+            name: "RNCryptor",
+            targets: ["RNCryptor"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "RNCryptor",
+            dependencies: [],
+            path: "RNCryptor"
+        )
+    ]
+)

--- a/RNCryptor.xcodeproj/project.pbxproj
+++ b/RNCryptor.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		659134EC1B14262C00B82A96 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		659134ED1B14262C00B82A96 /* RNCryptor iOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RNCryptor iOS.h"; sourceTree = "<group>"; };
 		659135141B142E6A00B82A96 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		6ED5915727EDC23000AF646B /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		AB13427A15E0FC2300456914 /* RNCryptor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RNCryptor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB13427E15E0FC2300456914 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		AB13427F15E0FC2300456914 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
@@ -329,6 +330,7 @@
 		FB7564E51512D3C4007B806B = {
 			isa = PBXGroup;
 			children = (
+				6ED5915727EDC23000AF646B /* Package.swift */,
 				FB7565241512D9BE007B8092 /* README.md */,
 				FB7564F51512D3C4007B806B /* RNCryptor */,
 				FB7565091512D3C4007B806B /* RNCryptorTests */,

--- a/RNCryptor/include/RNCryptor Package.h
+++ b/RNCryptor/include/RNCryptor Package.h
@@ -1,0 +1,1 @@
+../RNCryptor.h

--- a/RNCryptor/include/RNCryptor.h
+++ b/RNCryptor/include/RNCryptor.h
@@ -1,0 +1,29 @@
+//
+//  RNCryptor.h
+//
+//  Copyright (c) 2012 Rob Napier
+//
+//  This code is licensed under the MIT License:
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a
+//  copy of this software and associated documentation files (the "Software"),
+//  to deal in the Software without restriction, including without limitation
+//  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//  and/or sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+//  DEALINGS IN THE SOFTWARE.
+//
+
+#import "RNCryptor Package.h"
+#import "RNDecryptor.h"
+#import "RNEncryptor.h"

--- a/RNCryptor/include/RNDecryptor.h
+++ b/RNCryptor/include/RNDecryptor.h
@@ -1,0 +1,1 @@
+../RNDecryptor.h

--- a/RNCryptor/include/RNEncryptor.h
+++ b/RNCryptor/include/RNEncryptor.h
@@ -1,0 +1,1 @@
+../RNEncryptor.h


### PR DESCRIPTION
I'm working on improving the SPM support for [Ensembles 2](https://www.ensembles.io/) and RNCryptor-objc is a dependency. This PR adds a Package.swift, a header file and some header symlinks so RNCryptor-objc can be used as a Swift package dependency in other Swift packages.

By default SPM uses the `include` directory for public headers. But it can be overwritten via `publicHeaderPath`, if preferred. According to my current understanding all public headers should be inside this directory plus the umbrella header. Internal headers in other places can be specified via `.cSettings` and `.headerSearchPath`.